### PR TITLE
Allow Pycord and Discord.js invites through filter.

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -179,6 +179,8 @@ async def check_invite(bot, content, channel=None):
                     681882711945641997,  # TCA
                     782903894468198450,  # Swasville
                     336642139381301249,  # Discord.py
+                    222078108977594368,  # Discord.js
+                    881207955029110855,  # Pycord
                     267624335836053506,  # Python
                     412754940885467146,  # Blurple
                     613425648685547541,  # Discord Developers


### PR DESCRIPTION
# Proposal

With discord.py shutting down, allowing invites to Pycord (discord.py's replacement) and Discord.js (an alternative for people who wish to migrate) is crucial for helpers without the `Manage Messages` bypass.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (Please specify): 

## Has this been tested:

- [ ] Yes
- [ ] No
- [x] Not needed

# Checklist:

- [x] My code follows the style guidelines of this project

~~I have changed/added the help doc at the beginning of any commands changed/added.~~

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changed files do not include any files regularly changed in saves (something where my bot would interfere with this).
- [x] My changes generate no new warnings

~~I have tested and concluded that my changes are effective or that my feature works - If you have not tested, don't check this so I know to review it more. You may still make a PR for untested code.~~ 

- [x] My code does not cause issues with existing code
- [x] Any dependent changes have been merged and published in downstream modules

Struck through items do not apply to my change. The change only adds the guild IDs of Pycord and Discord.js to the list of allowed invite guild IDs.