### PR TITLE
Change all references to TCA

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -198,7 +198,7 @@ async def on_member_join(member):
     inviter = await bot.tracker.fetch_inviter(member)
     rules = member.guild.rules_channel.mention
     embed = discord.Embed(
-        title='Welcome to The Coding Academy!',
+        title='Welcome to The Coding Realm!',
         description=(
             f'Welcome {member.mention}, we\'re glad you joined! Before you get'
             ' started, here are some things to check out: \n**Read the Rules:'
@@ -220,7 +220,7 @@ async def on_member_join(member):
     d = ImageDraw.Draw(txt)
     fill = (255, 255, 255, 255)
     font = ImageFont.truetype("storage/fonts/Poppins/Poppins-Bold.ttf", 25)
-    text = "Welcome to The Coding Academy"
+    text = "Welcome to The Coding Realm"
     text_width, text_height = d.textsize(text, font)
     d.text(((txt.size[0] - text_width) // 2, (txt.size[1] // 31) * 1), text, font=font, fill=fill, align='center')
     font = ImageFont.truetype("storage/fonts/Poppins/Poppins-Bold.ttf", 15)
@@ -461,7 +461,7 @@ async def after_invoke(ctx):
 
 @tasks.loop(minutes=2)
 async def status_change():
-    statuses = ['over TCA', 'you', 'swas', '@everyone', 'general chat', 'discord', ',help', 'your mom', 
+    statuses = ['over TCR', 'you', 'swas', '@everyone', 'general chat', 'discord', ',help', 'your mom', 
                 'bob and shadow argue', 'swas simp for false', 'new members', 'the staff team', 
                 random.choice(bot.get_guild(681882711945641997).get_role(795145820210462771).members).name, 
                 'helpers', 'code', 'mass murders', 'karen be an idiot', 'a video', 'watches', 'bob', 

--- a/cogs/brawl.py
+++ b/cogs/brawl.py
@@ -48,15 +48,15 @@ class Brawl(commands.Cog):
 
     @commands.group(invoke_without_command=True)
     async def brawl(self, ctx):
-        embed=discord.Embed(title="TCA ***BRAWL*** Version 1.0.0", description="TCA Brawl is a turn-based fighting game written in Python and playable via a Discord bot. It includes all of your"
-        " favorite TCA members and former TCA members.", color=discord.Color.random())
+        embed=discord.Embed(title="TCR ***BRAWL*** Version 1.0.0", description="TCR Brawl is a turn-based fighting game written in Python and playable via a Discord bot. It includes all of your"
+        " favorite TCR members and former TCR members.", color=discord.Color.random())
         embed.add_field(name="How to Play:", value="Grab a friend and take a bot channel. Use the `brawl battle` command to get started! The `battle` command has two aliases,"
         " `fight` and `start`. You will be prompted to pick a character, then the game will begin! If you want info on a character before playing, use `brawl info`.", inline=False)
         embed.add_field(name="All Commands:", value="`brawl`, `info`, `help`, `faq`.", inline=False)
         embed.add_field(name="Our FAQ", value="You may want to suggest a character, or you don't want your own person in the game. Check the FAQ to see how to deal with stuff.", inline=False)
         embed.set_thumbnail(url="https://images-ext-2.discordapp.net/external/SydGsxAv1JDLCgm4qALPhcke7fv6TWoyVR2lQhEu-NI/%3Fsize%3D128/https/cdn.discordapp.com/icons/681882711945641997/a_2c2eeae970672cefecdb5b8536f42a47.gif")
         embed.set_image(url="https://media.discordapp.net/attachments/773319739581136916/864310160520249384/tcabrawl.png?width=1025&height=404")
-        embed.set_footer(text="TCA Brawl created by UnsoughtConch.")
+        embed.set_footer(text="TCR Brawl created by UnsoughtConch.")
 
         faq = discord.Embed(title="Frequently Asked Questions", description="These aren't really frequently asked.", color=discord.Color.random())
         faq.add_field(name="Why am I not a character here?", value="This has a few answers. You either aren't very familiar, we haven't got to you yet, or we can't think of a good moveset for you.")
@@ -64,7 +64,7 @@ class Brawl(commands.Cog):
         faq.add_field(name="I want to make improvements to the game/a character. Can I?", value="Of course! Make a pull request from [the Coding Bot repository](https://github.com/The-Coding-Academy/Coding-Bot-v4) and edit the JSON or code!")
         faq.add_field(name="How can I suggest a character?", value="Contact UnsoughtConch#9225.")
 
-        chars = discord.Embed(title="TCA ***BRAWL*** Characters")
+        chars = discord.Embed(title="TCR ***BRAWL*** Characters")
         for character in data:
             char = data[character]
             desc = f"Class: {char['class']}\nAttack One: {char['atk_1']['name']}\nAttack Two: {char['atk_2']['name']}\nAbility: {char['ability']['name']}"
@@ -137,10 +137,10 @@ class Brawl(commands.Cog):
     async def info(self, ctx):
         menu_opts = [] 
         char_embds = dict()
-        chars = discord.Embed(title="TCA ***BRAWL*** Characters", description="Select a character from the select menu to get started!")
+        chars = discord.Embed(title="TCR ***BRAWL*** Characters", description="Select a character from the select menu to get started!")
         for character in data:
             menu_opts.append(SelectOption(character, character))
-            embed = discord.Embed(title="TCA ***BRAWL*** | " + character, color=discord.Color.random(), description=f"Character Class: {data[character]['class']}")
+            embed = discord.Embed(title="TCR ***BRAWL*** | " + character, color=discord.Color.random(), description=f"Character Class: {data[character]['class']}")
             embed.add_field(name="Attack One:", value=f"NAME: {data[character]['atk_1']['name']}\nDAMAGE: {data[character]['atk_1']['dmg']}")
             embed.add_field(name="Attack Two:", value=f"NAME: {data[character]['atk_2']['name']}\nDAMAGE: {data[character]['atk_2']['dmg']}")
             type = data[character]['ability']['type']

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -240,7 +240,7 @@ class Moderation(commands.Cog):
         Manually verify a member.
         """
         if not ctx.guild.id == 681882711945641997:
-            return await ctx.send(embed=ctx.error('Must be in The Coding Academy'))
+            return await ctx.send(embed=ctx.error('Must be in The Coding Realm'))
         member = ctx.guild.get_role(744403871262179430)
         if member in target.roles:
             return await ctx.send(embed=ctx.error('Member is already verified'))


### PR DESCRIPTION
# Description

Following the rebranding of TCA, it made sense to change replace occurrences of `TCA` with `TCR` and `The Coding Academy` to `The Coding Realm`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (Please specify): 

# Has this been tested:

- [ ] Yes
- [ ] No
- [x] Not needed

# Checklist:

If any are false, you may still submit, but may be asked to make changes.

- [x] My code follows the style guidelines of this project
- [x] I have changed/added the help doc at the beginning of any commands changed/added.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changed files do not include any files regularly changed in saves (something where my bot would interfere with this).
- [x] My changes generate no new warnings
- [ ] I have tested and concluded that my changes are effective or that my feature works - If you have not tested, dont check this so I know to review it more. You may still make a PR for untested code.
- [x] My code does not cause issues with existing code
- [x] Any dependent changes have been merged and published in downstream modules

- [ ] Some of these options did not apply to my change (Please specify which): 
